### PR TITLE
#92 lando setup completed

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -2,6 +2,7 @@ name: custom-cms
 recipe: lamp
 config:
   webroot: .
+  database: mysql:8.0.27
 services:
   phpmyadmin:
     type: phpmyadmin

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,12 @@
+name: custom-cms
+recipe: lamp
+config:
+  webroot: .
+services:
+  phpmyadmin:
+    type: phpmyadmin
+    hosts:
+      - database
+proxy:
+  phpmyadmin:
+    - phpmyadmin.ecom.lndo.site


### PR DESCRIPTION
for setting up lando run `lando init`
to add phpmyadmin using lando add following code to lando.yml file.
```
services:
  phpmyadmin:
    type: phpmyadmin
    hosts:
      - database
proxy:
  phpmyadmin:
    - phpmyadmin.ecom.lndo.site
```
then run `lando start`
