### PR TITLE
#200: Solved the issue, the logged in username is visible now

### DIFF
--- a/src/Controllers/Article.php
+++ b/src/Controllers/Article.php
@@ -38,6 +38,7 @@ class Article extends ControllerBase
         }
         $variables['role'] = $_SESSION['role'];
         $variables['authenticated_userId'] = $_SESSION['user_id'];
+        $variables['username'] = $_SESSION['username'];
         $variables['title'] = $this->reverie . " | Article";
         echo $twig->render("articleForm.html.twig", $variables);
         return;


### PR DESCRIPTION
* Solved the issue and now that authenticated username is visible on the navbar on article-form template.
* Testing Steps : 
   * Login as admin or authenticated user.
   * click `add content` tab on navbar.
   * select `article` content.
   * check the navbar (next to logout button), the username will be visivble.

* Screenshot below : 

![Screenshot from 2022-01-12 19-11-46](https://user-images.githubusercontent.com/83503327/149151827-7fd9f90b-2253-42c8-b47a-548f1deedbf5.png)


