### PR TITLE
#256: Changed the button text of all blog cards from 'Go somewhere' to 'Read More'.

### DIFF
--- a/views/templates/article.html.twig
+++ b/views/templates/article.html.twig
@@ -58,7 +58,7 @@
 
 											<div class="card-body d-flex flex-column justify-content-around">
 												<h5 class="card-title">{{ r.title }}</h5>
-												<a href="article/{{ r.id }}" class="btn btn-primary">Go somewhere</a>
+												<a href="article/{{ r.id }}" class="btn btn-primary">Read More</a>
 											</div>
 										</div>
 									</div>

--- a/views/templates/home.html.twig
+++ b/views/templates/home.html.twig
@@ -75,7 +75,7 @@
               {{ (r.body|striptags|slice(0, 120)) ~ '...' }}
             </p>
             <a href="article/{{ r.id }}" class="btn btn-primary">
-              Go somewhere
+              Read More
             </a>
           </div>
         </div>
@@ -105,7 +105,7 @@
                 {{ (r.body|striptags|slice(0, 120)) ~ '...' }}
               </p>
               <a href="article/{{ r.id }}" class="btn btn-primary">
-                Go somewhere
+                Read More
               </a>
             </div>
           </div>


### PR DESCRIPTION
* Changed the button text "Go somwhere" of all blog cards to "Read more"
* Testing steps : 
    * Go to home page and check the blog card button. The 'Read more' text should be visible.
    * Go to article page and check for the same in related articles section.

![Screenshot from 2022-01-31 16-37-56](https://user-images.githubusercontent.com/83503327/151783846-156837fd-9521-4fdb-9eb9-95f3d828942a.png)

![Screenshot from 2022-01-31 16-37-47](https://user-images.githubusercontent.com/83503327/151783850-c48afce4-0b50-44e0-94de-7ff7334f1a12.png)
 